### PR TITLE
Run git_cl commands as a python step.

### DIFF
--- a/recipes/README.recipes.md
+++ b/recipes/README.recipes.md
@@ -522,7 +522,7 @@ dir_path (Path): directory to clone into
 remote_name (str): the remote name to rebase from if not origin
 ### *recipe_modules* / [git\_cl](/recipes/recipe_modules/git_cl)
 
-[DEPS](/recipes/recipe_modules/git_cl/__init__.py#1): [recipe\_engine/context][recipe_engine/recipe_modules/context], [recipe\_engine/raw\_io][recipe_engine/recipe_modules/raw_io], [recipe\_engine/step][recipe_engine/recipe_modules/step]
+[DEPS](/recipes/recipe_modules/git_cl/__init__.py#1): [recipe\_engine/context][recipe_engine/recipe_modules/context], [recipe\_engine/python][recipe_engine/recipe_modules/python], [recipe\_engine/raw\_io][recipe_engine/recipe_modules/raw_io]
 
 #### **class [GitClApi](/recipes/recipe_modules/git_cl/api.py#9)([RecipeApi][recipe_engine/wkt/RecipeApi]):**
 

--- a/recipes/recipe_modules/git_cl/__init__.py
+++ b/recipes/recipe_modules/git_cl/__init__.py
@@ -1,5 +1,5 @@
 DEPS = [
   'recipe_engine/context',
+  'recipe_engine/python',
   'recipe_engine/raw_io',
-  'recipe_engine/step',
 ]

--- a/recipes/recipe_modules/git_cl/api.py
+++ b/recipes/recipe_modules/git_cl/api.py
@@ -16,8 +16,8 @@ class GitClApi(recipe_api.RecipeApi):
 
     my_loc = self.c.repo_location if self.c else None
     with self.m.context(cwd=self.m.context.cwd or my_loc):
-      return self.m.step(
-          name, [self.repo_resource('git_cl.py'), subcmd] + args,
+      return self.m.python(
+          name, self.repo_resource('git_cl.py'), [subcmd] + args,
           **kwargs)
 
   def get_description(self, patch_url=None, codereview=None, **kwargs):

--- a/recipes/recipe_modules/git_cl/examples/full.expected/basic.json
+++ b/recipes/recipe_modules/git_cl/examples/full.expected/basic.json
@@ -1,6 +1,8 @@
 [
   {
     "cmd": [
+      "python",
+      "-u",
       "RECIPE_REPO[depot_tools]/git_cl.py",
       "upload",
       "--message-file",
@@ -10,6 +12,8 @@
   },
   {
     "cmd": [
+      "python",
+      "-u",
       "RECIPE_REPO[depot_tools]/git_cl.py",
       "issue"
     ],
@@ -17,6 +21,8 @@
   },
   {
     "cmd": [
+      "python",
+      "-u",
       "RECIPE_REPO[depot_tools]/git_cl.py",
       "description",
       "-d",
@@ -27,6 +33,8 @@
   },
   {
     "cmd": [
+      "python",
+      "-u",
       "RECIPE_REPO[depot_tools]/git_cl.py",
       "description",
       "-n",
@@ -46,6 +54,8 @@
   },
   {
     "cmd": [
+      "python",
+      "-u",
       "RECIPE_REPO[depot_tools]/git_cl.py",
       "description",
       "-d"
@@ -62,6 +72,8 @@
   },
   {
     "cmd": [
+      "python",
+      "-u",
       "RECIPE_REPO[depot_tools]/git_cl.py",
       "description",
       "-n",
@@ -73,6 +85,8 @@
   },
   {
     "cmd": [
+      "python",
+      "-u",
       "RECIPE_REPO[depot_tools]/git_cl.py",
       "description",
       "-d"


### PR DESCRIPTION
Otherwise this fails on Windows because git_cl.py "is not a valid Win32
application".

R=​gbeaty@google.com, iannucci@google.com

Bug: 726111
Change-Id: I4b9fea6b5271241e14407aeab175ce73d1ee8349

Change-Id: I4b9fea6b5271241e14407aeab175ce73d1ee8349
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/tools/depot_tools/+/1835598
Commit-Queue: Michael Moss <mmoss@chromium.org>
Reviewed-by: Garrett Beaty <gbeaty@chromium.org>
Reviewed-by: Robbie Iannucci <iannucci@chromium.org>
(cherry picked from commit 6b4c2a88f36eba12106e899b19c54c7b1d51b793)
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/tools/depot_tools/+/1846775
Auto-Submit: Michael Moss <mmoss@chromium.org>
Reviewed-by: Michael Moss <mmoss@chromium.org>