### PR TITLE
3987: bot_update: only add input commit refs for gclient solution roots.

### DIFF
--- a/recipes/README.recipes.md
+++ b/recipes/README.recipes.md
@@ -56,7 +56,7 @@ Recipe module to ensure a checkout is consistent on a bot.
 
 Wrapper for easy calling of bot_update.
 
-&mdash; **def [deapply\_patch](/recipes/recipe_modules/bot_update/api.py#500)(self, bot_update_step):**
+&mdash; **def [deapply\_patch](/recipes/recipe_modules/bot_update/api.py#504)(self, bot_update_step):**
 
 Deapplies a patch, taking care of DEPS and solution revisions properly.
     
@@ -87,7 +87,7 @@ Args:
   step_test_data: a null function that returns test bot_update.py output.
     Use test_api.output_json to generate test data.
 
-&mdash; **def [get\_project\_revision\_properties](/recipes/recipe_modules/bot_update/api.py#477)(self, project_name, gclient_config=None):**
+&mdash; **def [get\_project\_revision\_properties](/recipes/recipe_modules/bot_update/api.py#481)(self, project_name, gclient_config=None):**
 
 Returns all property names used for storing the checked-out revision of
 a given project.
@@ -105,7 +105,7 @@ Returns (list of str): All properties that'll hold the checked-out revision
 
 &emsp; **@property**<br>&mdash; **def [last\_returned\_properties](/recipes/recipe_modules/bot_update/api.py#36)(self):**
 
-&mdash; **def [resolve\_fixed\_revision](/recipes/recipe_modules/bot_update/api.py#427)(self, bot_update_json, name):**
+&mdash; **def [resolve\_fixed\_revision](/recipes/recipe_modules/bot_update/api.py#431)(self, bot_update_json, name):**
 
 Set a fixed revision for a single dependency using project revision
 properties.

--- a/recipes/recipe_modules/bot_update/api.py
+++ b/recipes/recipe_modules/bot_update/api.py
@@ -188,9 +188,13 @@ class BotUpdateApi(recipe_api.RecipeApi):
       # However, here we ignore it if the config specified a revision.
       # This is necessary because existing builders rely on this behavior,
       # e.g. they want to force refs/heads/master at the config level.
-      main_repo_path = self._get_commit_repo_path(in_commit, cfg)
-      revisions[main_repo_path] = revisions.get(main_repo_path) or in_commit_rev
-      if in_commit.id and in_commit.ref:
+      in_commit_repo_path = self._get_commit_repo_path(in_commit, cfg)
+      revisions[in_commit_repo_path] = (
+          revisions.get(in_commit_repo_path) or in_commit_rev)
+      parsed_solution_urls = set(
+          self.m.gitiles.parse_repo_url(s.url) for s in cfg.solutions)
+      if (in_commit.id and in_commit.ref
+          and (in_commit.host, in_commit.project) in parsed_solution_urls):
         refs = [in_commit.ref] + refs
 
     # Guarantee that first solution has a revision.

--- a/recipes/recipe_modules/bot_update/examples/full.py
+++ b/recipes/recipe_modules/bot_update/examples/full.py
@@ -90,13 +90,13 @@ def GenTests(api):
   def try_build(**kwargs):
     kwargs.setdefault(
         'git_repo', 'https://chromium.googlesource.com/chromium/src')
-    return api.buildbucket.try_build('chromium', 'linux', **kwargs)
+    return api.buildbucket.try_build('chromium/src', 'try', 'linux', **kwargs)
 
   def ci_build(**kwargs):
     kwargs.setdefault(
         'git_repo', 'https://chromium.googlesource.com/chromium/src')
     return (
-        api.buildbucket.ci_build('chromium', 'linux', **kwargs) +
+        api.buildbucket.ci_build('chromium/src', 'ci', 'linux', **kwargs) +
         api.properties(patch=False)
     )
 


### PR DESCRIPTION
Bug: 1031805
Tbr: agable@chromium.org
Change-Id: I6edd221900eadd4d621d6190e08b61fdbc2f8621 Reviewed-on: https://chromium-review.googlesource.com/c/chromium/tools/depot_tools/+/1958706
Commit-Queue: John Budorick <jbudorick@chromium.org>
Reviewed-by: Aaron Gable <agable@chromium.org>
(cherry picked from commit e9aeaee522332ff7075529cc4bf2c81f5ade3318)
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/tools/depot_tools/+/1959693
Reviewed-by: John Budorick <jbudorick@chromium.org>